### PR TITLE
Fix automation to work on Kubernetes 1.27.7 ( AKS tf module 7.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ terraform apply -auto-approve -var-file=terraform.tfvars
 The template will install AKS and call the ArgoCD module to install everything that is in this repo under the `/apps` folder, including `cert-manager` and `ingress-nginx`. To allow for the certificates creation, you need to map the ingress public IP to a real wildcard DNS record in a DNS zone (in Azure):
 
 ```console
-INGRESS_IP=`kg svc -n ingress ingress-nginx-controller --output=jsonpath="{.status.loadBalancer.ingress[0]['ip']}"`
+INGRESS_IP=`kubectl get svc -n ingress ingress-nginx-controller --output=jsonpath="{.status.loadBalancer.ingress[0]['ip']}"`
 az network dns record-set a delete  -g dns -z donhighthecontainerguy.com -y -n "*.ingress"
 az network dns record-set a add-record  -n "*.ingress" -g dns -z donhighthecontainerguy.com --ipv4-address $INGRESS_IP
 az network dns record-set a update  -n "*.ingress" -g dns -z donhighthecontainerguy.com --set ttl=10

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ```console
 terraform init
-terraform apply -auto-approve
+cp terraform.tfvarsexample terraform.tfvars
+terraform apply -auto-approve -var-file=terraform.tfvars
 ```
 
 The template will install AKS and call the ArgoCD module to install everything that is in this repo under the `/apps` folder, including `cert-manager` and `ingress-nginx`. To allow for the certificates creation, you need to map the ingress public IP to a real wildcard DNS record in a DNS zone (in Azure):

--- a/manifests/argocd/argocd-ingress.yaml
+++ b/manifests/argocd/argocd-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: "networking.k8s.io/v1beta1"
+apiVersion: "networking.k8s.io/v1"
 kind: Ingress
 metadata:
   name: argocd-server
@@ -14,8 +14,11 @@ spec:
   rules:
     - http:
         paths:
-          - path:
+          - path: "/"
+            pathType: Prefix
             backend:
-              serviceName: argocd-server
-              servicePort: http
+              service:
+                name: argocd-server
+                port:
+                  name: http
       #host: argocd.ingress.stackmasters.com

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,6 +20,7 @@ resource "azurerm_subnet" "argocd" {
 
 module "aks" {
   source                         = "Azure/aks/azurerm"
+  version                        = "4.16.0"
   resource_group_name            = var.resource_group_name
   kubernetes_version             = var.kubernetes_version
   orchestrator_version           = var.kubernetes_version

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,22 +19,23 @@ resource "azurerm_subnet" "argocd" {
 }
 
 module "aks" {
-  source                         = "Azure/aks/azurerm"
-  version                        = "4.16.0"
-  resource_group_name            = var.resource_group_name
-  kubernetes_version             = var.kubernetes_version
-  orchestrator_version           = var.kubernetes_version
-  prefix                         = "sm"
-  network_plugin                 = "kubenet"
-  public_ssh_key                 = var.public_ssh_key
-  vnet_subnet_id                 = azurerm_subnet.argocd.id
-  enable_log_analytics_workspace = false
-
+  source               = "Azure/aks/azurerm"
+  version              = "7.5.0"
+  resource_group_name  = var.resource_group_name
+  kubernetes_version   = var.kubernetes_version
+  orchestrator_version = var.kubernetes_version
+  prefix               = "sm"
+  network_plugin       = "kubenet"
+  public_ssh_key       = var.public_ssh_key
+  vnet_subnet_id       = azurerm_subnet.argocd.id
 
   agents_count = var.agents_count
   agents_size  = var.agents_size
 
   network_policy = "calico"
+
+  role_based_access_control_enabled = true
+  rbac_aad                          = false
 
   depends_on = [azurerm_subnet.argocd]
 

--- a/terraform/terraform.tfvarsexample
+++ b/terraform/terraform.tfvarsexample
@@ -5,7 +5,6 @@ vnet_address_prefix   = ["172.20.0.0/16"]
 subnet_address_prefix = ["172.20.1.0/24"]
 agents_count          = 3
 agents_size           = "Standard_B8ms"
-kubernetes_version    = "1.19.3"
 bootstrap_repo_url    = "https://github.com/ams0/argocd-apps"
 bootstrap_repo_path   = "manifests"
 bootstrap_repo_branch = "main"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,7 +13,6 @@ variable "public_ssh_key" {
   default     = ""
 }
 
-
 variable "vnet_address_prefix" {
   description = "vnet_address_prefix"
   default     = ""
@@ -36,7 +35,7 @@ variable "agents_size" {
 
 variable "kubernetes_version" {
   description = "kubernetes_version"
-  default     = ""
+  default     = null
 }
 
 variable "service_mesh_type" {


### PR DESCRIPTION
Please merge first PR #1  for a clean apply of this PR.

* Bumps TF AKS module to 7.5.0
* Passes `null` as kubernetes version to install the latest AKS
* Updates the Ingress declaration because `networking.k8s.io/v1beta1` is not supported anymore in Kubernetes 1.27.7
